### PR TITLE
Fix issue #1

### DIFF
--- a/Core/Inc/GAUL_Drivers/L76LM33.h
+++ b/Core/Inc/GAUL_Drivers/L76LM33.h
@@ -13,7 +13,7 @@
 #ifndef INC_GAUL_DRIVERS_L76LM33_H_
 #define INC_GAUL_DRIVERS_L76LM33_H_
 
-#define L76LM33_BUFFER_SIZES 128  // NMEA sentence is around 80 char max, has to be a power of two.
+#define L76LM33_BUFFER_SIZES 256  // NMEA sentence is around 80 char max, has to be a power of two.
 #define L76LM33_UART_TIMEOUT 1000 // For UART transmit
 
 typedef struct {

--- a/Core/Src/GAUL_Drivers/Tests/L76LM33_tests.c
+++ b/Core/Src/GAUL_Drivers/Tests/L76LM33_tests.c
@@ -57,4 +57,5 @@ void L76LM33_TESTS_LogStructure(L76LM33 *L76_data) {
 	printf("Fix:  %s\n", L76_data->fix == 1 ? "Yes" : "No");
 	printf("Lat:  %f\n", L76_data->latitude);
 	printf("Lon:  %f\n", L76_data->longitude);
+	printf("\n");
 }

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -143,7 +143,8 @@ int main(void)
 
     // L76LM33
     //L76LM33_TESTS_ReadSentence_LogSTLINK();
-    L76LM33_TESTS_ReadSentence_LogUART(&huart1);
+    //L76LM33_TESTS_ReadSentence_LogUART(&huart1);
+    L76LM33_TESTS_Read_LogSTLINK();
 
     HAL_Delay(200);
   }

--- a/arduino_debug_code/arduino_debug_code.ino
+++ b/arduino_debug_code/arduino_debug_code.ino
@@ -51,4 +51,8 @@ void loop() {
   Serial.println(i, DEC);
   i++;
   delay(1200);
+
+  if (i >= 900) {
+    i = 0;
+  }
 }


### PR DESCRIPTION
- Ajout d'un flag pour ne pas lire le buffer UART quand la transmission du module GNSS n'est pas finie.
- Buffer plus gros pour pouvoir stocker 2 trames NMEA dans le cas où la deuxième trame n'est pas bonne.